### PR TITLE
feat(command-palette): make shortcut key configurable via env var

### DIFF
--- a/packages/pi-command-palette/README.md
+++ b/packages/pi-command-palette/README.md
@@ -24,7 +24,7 @@ Or add to `~/.pi/agent/settings.json`:
 
 | Shortcut | Action |
 |----------|--------|
-| `Ctrl+Shift+P` | Open command palette |
+| `Ctrl+Shift+P` _(default, configurable)_ | Open command palette |
 
 The palette lists:
 
@@ -42,4 +42,28 @@ The "Model: Switch Model" action opens a secondary overlay listing all models wi
 
 ## Configuration
 
-No configuration needed. Works out of the box.
+The default shortcut is `Ctrl+Shift+P`. If it conflicts with your terminal, override it via either of the following (evaluated in order, first match wins).
+
+### 1. Environment variable
+
+Useful for terminals that intercept `Ctrl+Shift+<key>` before it reaches the session (e.g. Termius on Windows/WSL2):
+
+```bash
+export PI_COMMAND_PALETTE_KEY=ctrl+alt+k
+```
+
+Add it to your shell profile to persist (`~/.zshrc` on macOS, `~/.bashrc` on bash).
+
+### 2. settings.json
+
+Set `commandPalette.shortcut` in `~/.pi/agent/settings.json` (global) or `.pi/settings.json` in your project (project overrides global):
+
+```jsonc
+{
+  "commandPalette": {
+    "shortcut": "ctrl+alt+k"
+  }
+}
+```
+
+Any valid pi keybinding string works (e.g. `ctrl+shift+k`, `ctrl+alt+p`, `ctrl+k`). Restart pi (or run `/reload`) after changing the shortcut.

--- a/packages/pi-command-palette/src/config.ts
+++ b/packages/pi-command-palette/src/config.ts
@@ -1,0 +1,67 @@
+/**
+ * Resolve the command-palette shortcut key from configuration sources.
+ *
+ * Priority (highest wins):
+ *   1. `PI_COMMAND_PALETTE_KEY` env var — works even when the terminal intercepts
+ *      `Ctrl+Shift+P` before it reaches the session (e.g. Termius on Windows/WSL2).
+ *   2. `settings.json` `commandPalette.shortcut` (project `.pi/settings.json`
+ *      overrides global `~/.pi/agent/settings.json`)
+ *   3. default `"ctrl+shift+p"`
+ *
+ * Why not a CLI flag? Flags are applied to the extension runtime AFTER extensions
+ * load, so `pi.getFlag()` only returns the registered default at `registerShortcut()`
+ * time. Env vars and settings files are both available immediately at process
+ * start, so they are the correct mechanisms here.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { KeyId } from "@earendil-works/pi-tui";
+
+export const DEFAULT_SHORTCUT = "ctrl+shift+p";
+
+function getAgentDir(): string {
+	const envDir = process.env.PI_AGENT_DIR;
+	if (envDir) return envDir;
+	return path.join(os.homedir(), ".pi", "agent");
+}
+
+function readSettings(filePath: string): Record<string, unknown> {
+	try {
+		if (!fs.existsSync(filePath)) return {};
+		return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	} catch {
+		return {};
+	}
+}
+
+/** Lowercase + trim; returns undefined for empty/non-string input. */
+function normalizeKey(raw: unknown): string | undefined {
+	if (typeof raw !== "string") return undefined;
+	const trimmed = raw.trim().toLowerCase();
+	return trimmed || undefined;
+}
+
+/**
+ * Resolve the command-palette shortcut key from env var → settings → default.
+ *
+ * @param cwd - Project working directory, for project-level settings override.
+ *   Defaults to `process.cwd()` (accurate at pi startup when shortcuts register).
+ */
+export function resolveShortcutKey(cwd: string = process.cwd()): KeyId {
+	// 1. Env var — highest priority, for terminals that intercept the default combo.
+	const envKey = normalizeKey(process.env.PI_COMMAND_PALETTE_KEY);
+	if (envKey) return envKey as KeyId;
+
+	// 2. settings.json — global ~/.pi/agent/settings.json; project overrides global.
+	const globalSettings = readSettings(path.join(getAgentDir(), "settings.json"));
+	const projectSettings = readSettings(path.join(cwd, ".pi", "settings.json"));
+	const globalCfg = (globalSettings.commandPalette ?? {}) as { shortcut?: unknown };
+	const projectCfg = (projectSettings.commandPalette ?? {}) as { shortcut?: unknown };
+	const settingsKey = normalizeKey(projectCfg.shortcut ?? globalCfg.shortcut);
+	if (settingsKey) return settingsKey as KeyId;
+
+	// 3. default
+	return DEFAULT_SHORTCUT as KeyId;
+}

--- a/packages/pi-command-palette/src/index.ts
+++ b/packages/pi-command-palette/src/index.ts
@@ -23,6 +23,7 @@ import {
 	SelectList,
 	Text,
 } from "@earendil-works/pi-tui";
+import { resolveShortcutKey } from "./config.ts";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -389,7 +390,7 @@ async function showCommandPalette(pi: ExtensionAPI, ctx: ExtensionContext): Prom
 // ── Extension entry point ──────────────────────────────────────────
 
 export default function commandPaletteExtension(pi: ExtensionAPI) {
-	pi.registerShortcut("ctrl+shift+p", {
+	pi.registerShortcut(resolveShortcutKey(), {
 		description: "Open command palette",
 		handler: async (ctx) => {
 			await showCommandPalette(pi, ctx);


### PR DESCRIPTION
## What

Adds a `PI_COMMAND_PALETTE_KEY` environment variable so users can override the default `Ctrl+Shift+P` shortcut without editing source code.

## Why

Some terminals (e.g. Termius on Windows/WSL2) intercept `Ctrl+Shift+<key>` combos before they reach the terminal session, making the default shortcut unusable. This env var lets users bind the command palette to any key that works in their environment.

## Usage

```bash
export PI_COMMAND_PALETTE_KEY=ctrl+alt+k
```

Add to shell profile (`~/.bashrc`, `~/.zshrc`) to persist.

## Implementation note

CLI flags (`--flag`) are applied **after** extensions load, so they cannot be read during `registerShortcut()`. Environment variables are available immediately at process start, making them the correct mechanism here.