### PR TITLE
feat(pi-usage-block): add Kimi For Coding usage provider

### DIFF
--- a/packages/pi-usage-block/README.md
+++ b/packages/pi-usage-block/README.md
@@ -51,8 +51,9 @@ The following pi providers are supported out of the box — no extra plugin need
 | OpenCode Go | quota % | `GET opencode.ai/zen/go/v1/usage` |
 | Z.AI | quota % | `GET api.z.ai/api/monitor/usage/quota/limit` |
 | Z.AI Coding CN | quota % | `GET open.bigmodel.cn/api/monitor/usage/quota/limit` |
+| Kimi For Coding | quota % | `GET api.kimi.com/coding/v1/usages` |
 
-> **Notes:** OpenAI Codex uses the ChatGPT OAuth credential and an undocumented ChatGPT backend usage endpoint; it is separate from the public OpenAI API-key provider. Google Gemini and Mistral don't surface response headers in pi's call path. Groq's rate-limit headers are undocumented/unstable, and Fireworks only exposes limit (no remaining/reset).
+> **Notes:** OpenAI Codex uses the ChatGPT OAuth credential and an undocumented ChatGPT backend usage endpoint; it is separate from the public OpenAI API-key provider. Kimi For Coding reads the managed usage endpoint the official kimi-code CLI uses (weekly summary + 5h rolling window; the optional prepaid booster wallet is not shown). Google Gemini and Mistral don't surface response headers in pi's call path. Groq's rate-limit headers are undocumented/unstable, and Fireworks only exposes limit (no remaining/reset).
 
 ## Configuration
 

--- a/packages/pi-usage-block/src/builtin.test.ts
+++ b/packages/pi-usage-block/src/builtin.test.ts
@@ -153,7 +153,7 @@ test("Kimi For Coding drops malformed rows and unknown windows", async () => {
     limits: [
       { name: "dup-a", window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" }, detail: { used: "1", limit: "100" } },
       { name: "dup-b", window: { duration: 5, timeUnit: "TIME_UNIT_HOUR" }, detail: { used: "2", limit: "100" } }, // 5h == 300min → duplicate
-      { name: "unknown", window: { duration: 1, timeUnit: "TIME_UNIT_MONTH" }, detail: { used: "3", limit: "100" } },
+      { name: "unknown", window: { duration: 1, timeUnit: "TIME_UNIT_FORTNIGHT" }, detail: { used: "3", limit: "100" } },
       { name: "bad-reset", window: { duration: 24, timeUnit: "TIME_UNIT_HOUR" }, detail: { used: "5", limit: "100", resetTime: "invalid" } },
       { name: "missing-used", window: { duration: 7, timeUnit: "TIME_UNIT_DAY" }, detail: { limit: "100" } },
     ],
@@ -194,6 +194,25 @@ test("Kimi For Coding derives used from remaining and tolerates alternate field 
     { period: "5h", used: 15, limit: 100, unit: "requests", resetAt: new Date("2030-01-01T05:00:00.000Z") },
     { period: "daily", used: 5, limit: 100, unit: "requests", resetAt: new Date("2030-01-02T00:00:00.000Z") },
     { period: "weekly", used: 26, limit: 100, unit: "requests", resetAt: new Date("2030-01-07T00:00:00.000Z") },
+  ]);
+});
+
+test("Kimi For Coding maps a monthly window", async () => {
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    limits: [{
+      window: { duration: 1, timeUnit: "TIME_UNIT_MONTH" },
+      detail: { used: "26", limit: "100", resetTime: "2030-02-01T00:00:00.000Z" },
+    }],
+  }), { status: 200 })) as typeof fetch;
+
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({ apiKey: "kimi-key", resolveApiKey: async () => "kimi-key" });
+  assert.equal(provider.kind, "quota");
+  assert.ok(provider.fetchUsage);
+
+  assert.deepEqual(await provider.fetchUsage(), [
+    { period: "monthly", used: 26, limit: 100, unit: "requests", resetAt: new Date("2030-02-01T00:00:00.000Z") },
   ]);
 });
 

--- a/packages/pi-usage-block/src/builtin.test.ts
+++ b/packages/pi-usage-block/src/builtin.test.ts
@@ -83,3 +83,135 @@ test("OpenAI Codex refreshes its OAuth token before each usage poll", async () =
   assert.equal(resolved, 1);
   assert.equal(accountHeader, "refreshed-account");
 });
+
+test("Kimi For Coding polls the usage endpoint and maps weekly + five-hour windows", async () => {
+  let requestUrl = "";
+  let authHeader = "";
+
+  globalThis.fetch = (async (input, init) => {
+    requestUrl = String(input);
+    authHeader = new Headers(init?.headers).get("authorization") ?? "";
+    // Combined shape: weekly summary + a 5h row (numeric-string counts,
+    // string duration) — the payload the coding plan normally returns.
+    return new Response(JSON.stringify({
+      usage: { name: "Weekly limit", used: "40", limit: "1000", resetTime: "2030-01-07T00:00:00.000Z" },
+      limits: [{
+        name: "Five-hour limit",
+        window: { duration: "300", timeUnit: "TIME_UNIT_MINUTE" },
+        detail: { used: "1", limit: "100", resetTime: "2030-01-01T05:00:00.000Z" },
+      }],
+    }), { status: 200 });
+  }) as typeof fetch;
+
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({ apiKey: "kimi-key", resolveApiKey: async () => "kimi-key" });
+
+  assert.equal(provider.kind, "quota");
+  assert.equal(provider.source, "api");
+  assert.ok(provider.fetchUsage);
+
+  const windows = await provider.fetchUsage();
+  // Shortest window first: 5h (300 min) before weekly (10080 min).
+  assert.deepEqual(windows, [
+    { period: "5h", used: 1, limit: 100, unit: "requests", resetAt: new Date("2030-01-01T05:00:00.000Z") },
+    { period: "weekly", used: 40, limit: 1000, unit: "requests", resetAt: new Date("2030-01-07T00:00:00.000Z") },
+  ]);
+  assert.equal(requestUrl, "https://api.kimi.com/coding/v1/usages");
+  assert.equal(authHeader, "Bearer kimi-key");
+});
+
+test("Kimi For Coding maps numeric windows and collapses duplicate weekly rows", async () => {
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    usage: { used: "40", limit: "1000" },
+    limits: [
+      // Same weekly window as the summary via numeric fields → collapses to one.
+      { name: "Weekly cap", window: { duration: 1, timeUnit: "TIME_UNIT_WEEK" }, detail: { used: 99, limit: 999 } },
+      // Numeric duration + DAY unit → "daily".
+      { name: "Daily cap", window: { duration: 1, timeUnit: "TIME_UNIT_DAY" }, detail: { used: 5, limit: 100, resetTime: "2030-01-02T00:00:00Z" } },
+    ],
+  }), { status: 200 })) as typeof fetch;
+
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({ apiKey: "kimi-key", resolveApiKey: async () => "kimi-key" });
+
+  assert.equal(provider.kind, "quota");
+  assert.ok(provider.fetchUsage);
+
+  const windows = await provider.fetchUsage();
+  assert.deepEqual(windows, [
+    { period: "daily", used: 5, limit: 100, unit: "requests", resetAt: new Date("2030-01-02T00:00:00Z") },
+    // Summary row wins over the duplicate weekly limits row.
+    { period: "weekly", used: 40, limit: 1000, unit: "requests", resetAt: undefined },
+  ]);
+});
+
+test("Kimi For Coding drops malformed rows and unknown windows", async () => {
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    usage: { used: "-1", limit: "10.5", resetTime: "not-a-timestamp" }, // negative + fractional → dropped
+    limits: [
+      { name: "dup-a", window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" }, detail: { used: "1", limit: "100" } },
+      { name: "dup-b", window: { duration: 5, timeUnit: "TIME_UNIT_HOUR" }, detail: { used: "2", limit: "100" } }, // 5h == 300min → duplicate
+      { name: "unknown", window: { duration: 1, timeUnit: "TIME_UNIT_MONTH" }, detail: { used: "3", limit: "100" } },
+      { name: "bad-reset", window: { duration: 24, timeUnit: "TIME_UNIT_HOUR" }, detail: { used: "5", limit: "100", resetTime: "invalid" } },
+      { name: "missing-used", window: { duration: 7, timeUnit: "TIME_UNIT_DAY" }, detail: { limit: "100" } },
+    ],
+  }), { status: 200 })) as typeof fetch;
+
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({ apiKey: "kimi-key", resolveApiKey: async () => "kimi-key" });
+  assert.equal(provider.kind, "quota");
+  assert.ok(provider.fetchUsage);
+
+  const windows = await provider.fetchUsage();
+  assert.deepEqual(windows, [
+    { period: "5h", used: 1, limit: 100, unit: "requests", resetAt: undefined },
+    { period: "daily", used: 5, limit: 100, unit: "requests", resetAt: undefined }, // kept, invalid reset dropped
+  ]);
+});
+
+test("Kimi For Coding returns empty for an empty payload", async () => {
+  globalThis.fetch = (async () => new Response(JSON.stringify({}), { status: 200 })) as typeof fetch;
+
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({ apiKey: "kimi-key", resolveApiKey: async () => "kimi-key" });
+  assert.equal(provider.kind, "quota");
+  assert.ok(provider.fetchUsage);
+  assert.deepEqual(await provider.fetchUsage(), []);
+});
+
+test("Kimi For Coding re-resolves its credential before each usage poll", async () => {
+  let authHeader = "";
+  let resolved = 0;
+  globalThis.fetch = (async (_input, init) => {
+    authHeader = new Headers(init?.headers).get("authorization") ?? "";
+    return new Response(JSON.stringify({}), { status: 200 });
+  }) as typeof fetch;
+
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({
+    apiKey: "initial-key",
+    resolveApiKey: async () => {
+      resolved++;
+      return `refreshed-key-${resolved}`;
+    },
+  });
+  assert.equal(provider.kind, "quota");
+  assert.ok(provider.fetchUsage);
+  await provider.fetchUsage();
+  assert.equal(resolved, 1);
+  assert.equal(authHeader, "Bearer refreshed-key-1");
+});
+
+test("Kimi For Coding throws when no credential is available", async () => {
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({ apiKey: "unused", resolveApiKey: async () => undefined });
+  assert.equal(provider.kind, "quota");
+  assert.ok(provider.fetchUsage);
+  await assert.rejects(provider.fetchUsage(), /credential unavailable/);
+});

--- a/packages/pi-usage-block/src/builtin.test.ts
+++ b/packages/pi-usage-block/src/builtin.test.ts
@@ -172,6 +172,31 @@ test("Kimi For Coding drops malformed rows and unknown windows", async () => {
   ]);
 });
 
+test("Kimi For Coding derives used from remaining and tolerates alternate field spellings", async () => {
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    // `remaining` instead of `used`, plus the `resetAt` spelling.
+    usage: { limit: "100", remaining: "74", resetAt: "2030-01-07T00:00:00.000Z" },
+    limits: [
+      // Bare timeUnit (as the official CLI's fixtures spell it) + snake_case reset.
+      { window: { duration: 300, timeUnit: "minute" }, detail: { limit: "100", remaining: "85", reset_time: "2030-01-01T05:00:00.000Z" } },
+      // `used` wins when both counts are present; an unparsable resetTime falls through to resetAt.
+      { window: { duration: 1, timeUnit: "TIME_UNIT_DAY" }, detail: { used: "5", remaining: "99", limit: "100", resetTime: "not-a-date", resetAt: "2030-01-02T00:00:00.000Z" } },
+    ],
+  }), { status: 200 })) as typeof fetch;
+
+  const definition = BUILTIN_PROVIDERS.find((provider) => provider.id === "kimi-coding");
+  assert.ok(definition);
+  const provider = definition.build({ apiKey: "kimi-key", resolveApiKey: async () => "kimi-key" });
+  assert.equal(provider.kind, "quota");
+  assert.ok(provider.fetchUsage);
+
+  assert.deepEqual(await provider.fetchUsage(), [
+    { period: "5h", used: 15, limit: 100, unit: "requests", resetAt: new Date("2030-01-01T05:00:00.000Z") },
+    { period: "daily", used: 5, limit: 100, unit: "requests", resetAt: new Date("2030-01-02T00:00:00.000Z") },
+    { period: "weekly", used: 26, limit: 100, unit: "requests", resetAt: new Date("2030-01-07T00:00:00.000Z") },
+  ]);
+});
+
 test("Kimi For Coding returns empty for an empty payload", async () => {
   globalThis.fetch = (async () => new Response(JSON.stringify({}), { status: 200 })) as typeof fetch;
 

--- a/packages/pi-usage-block/src/builtin.ts
+++ b/packages/pi-usage-block/src/builtin.ts
@@ -332,12 +332,19 @@ async function zhipuCodingQuota(host: string, apiKey: string): Promise<QuotaWind
 
 // ── Kimi For Coding ───────────────────────────────────────────────────────
 
-/** Proto-style timeUnit enum → minutes multiplier. */
+/**
+ * timeUnit → minutes multiplier, keyed by the bare unit. The endpoint sends
+ * the proto-style `TIME_UNIT_MINUTE`; the official CLI's own fixtures use the
+ * bare `MINUTE`, so both spellings (any case) are accepted.
+ *
+ * Units outside this table (e.g. `TIME_UNIT_MONTH`) yield no window at all —
+ * the display model covers 5h / daily / weekly windows only.
+ */
 const KIMI_TIME_UNIT_MINUTES: Record<string, number> = {
-  TIME_UNIT_MINUTE: 1,
-  TIME_UNIT_HOUR: 60,
-  TIME_UNIT_DAY: 1440,
-  TIME_UNIT_WEEK: 10080,
+  MINUTE: 1,
+  HOUR: 60,
+  DAY: 1440,
+  WEEK: 10080,
 };
 
 /** Non-negative integer, arriving as a decimal string or a number. */
@@ -352,10 +359,16 @@ function kimiInt(value: unknown): number | undefined {
   return undefined;
 }
 
+/** Minutes multiplier for a limits[] item's `window.timeUnit`. */
+function kimiTimeUnitMultiplier(raw: unknown): number | undefined {
+  if (typeof raw !== "string") return undefined;
+  return KIMI_TIME_UNIT_MINUTES[raw.trim().toUpperCase().replace(/^TIME_UNIT_/, "")];
+}
+
 /** Rolling-window minutes from a limits[] item's proto-style `window`. */
 function kimiWindowMinutes(item: any): number | undefined {
   const duration = kimiInt(item?.window?.duration);
-  const multiplier = KIMI_TIME_UNIT_MINUTES[item?.window?.timeUnit];
+  const multiplier = kimiTimeUnitMultiplier(item?.window?.timeUnit);
   if (duration === undefined || duration === 0 || multiplier === undefined) return undefined;
   return duration * multiplier;
 }
@@ -370,18 +383,33 @@ function kimiPeriodLabel(minutes: number): string {
   return `${minutes}m`;
 }
 
-/** One usage row (`detail`) → QuotaWindow. Skips non-integer/zero-limit rows. */
+/** The row's reset timestamp, under any of the spellings the endpoint uses. */
+function kimiResetAt(detail: any): Date | undefined {
+  for (const key of ["resetTime", "resetAt", "reset_time", "reset_at"]) {
+    const value = detail?.[key];
+    if (typeof value !== "string") continue;
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  return undefined;
+}
+
+/** One usage row (`detail`) → QuotaWindow. Skips rows without usable counts. */
 function kimiRow(detail: any, period: string): QuotaWindow | undefined {
-  const used = kimiInt(detail?.used);
   const limit = kimiInt(detail?.limit);
+  // Some payloads report only `remaining`; QuotaWindow.used is consumed.
+  let used = kimiInt(detail?.used);
+  if (used === undefined && limit !== undefined) {
+    const remaining = kimiInt(detail?.remaining);
+    if (remaining !== undefined) used = limit - remaining;
+  }
   if (used === undefined || limit === undefined || limit === 0) return undefined;
-  const reset = typeof detail?.resetTime === "string" ? new Date(detail.resetTime) : undefined;
   return {
     period,
     used,
     limit,
     unit: "requests", // plan usage counts — the endpoint exposes no finer unit
-    resetAt: reset !== undefined && !Number.isNaN(reset.getTime()) ? reset : undefined,
+    resetAt: kimiResetAt(detail),
   };
 }
 
@@ -390,9 +418,13 @@ function kimiRow(detail: any, period: string): QuotaWindow | undefined {
  *
  * `usage` is the plan's weekly summary (the backend omits its window);
  * `limits[]` carries per-window rows (the 5-hour limit arrives as duration
- * 300 TIME_UNIT_MINUTE). Numbers arrive as decimal strings or numbers.
- * Duplicate windows collapse to one (summary wins), rows sort shortest
- * window first. The optional `boosterWallet` (prepaid balance) is not
+ * 300 TIME_UNIT_MINUTE). Counts arrive as decimal strings or numbers, and
+ * some payloads report `remaining` instead of `used`. Duplicate windows
+ * collapse to one (summary wins), rows sort shortest window first.
+ *
+ * Only the units in {@link KIMI_TIME_UNIT_MINUTES} are mapped: a
+ * `TIME_UNIT_MONTH` row is dropped until the display handles monthly
+ * windows. The optional `boosterWallet` (prepaid balance) is likewise not
  * mapped — a balance does not fit the quota-window display.
  */
 function parseKimiUsage(data: any): QuotaWindow[] {

--- a/packages/pi-usage-block/src/builtin.ts
+++ b/packages/pi-usage-block/src/builtin.ts
@@ -336,15 +336,17 @@ async function zhipuCodingQuota(host: string, apiKey: string): Promise<QuotaWind
  * timeUnit → minutes multiplier, keyed by the bare unit. The endpoint sends
  * the proto-style `TIME_UNIT_MINUTE`; the official CLI's own fixtures use the
  * bare `MINUTE`, so both spellings (any case) are accepted.
+ * Units outside this table yield no window at all.
  *
- * Units outside this table (e.g. `TIME_UNIT_MONTH`) yield no window at all —
- * the display model covers 5h / daily / weekly windows only.
+ * `MONTH` counts as 30 days: the duration is only a sort/dedupe key and the
+ * basis for the period label, so the calendar-month imprecision is harmless.
  */
 const KIMI_TIME_UNIT_MINUTES: Record<string, number> = {
   MINUTE: 1,
   HOUR: 60,
   DAY: 1440,
   WEEK: 10080,
+  MONTH: 43200,
 };
 
 /** Non-negative integer, arriving as a decimal string or a number. */
@@ -373,11 +375,12 @@ function kimiWindowMinutes(item: any): number | undefined {
   return duration * multiplier;
 }
 
-/** Short period label: "5h", "daily", "weekly", … */
+/** Short period label: "5h", "daily", "weekly", "monthly", … */
 function kimiPeriodLabel(minutes: number): string {
   if (minutes === 300) return "5h";
   if (minutes === 1440) return "daily";
   if (minutes === 10080) return "weekly";
+  if (minutes === 43200) return "monthly";
   if (minutes % 1440 === 0) return `${minutes / 1440}d`;
   if (minutes % 60 === 0) return `${minutes / 60}h`;
   return `${minutes}m`;
@@ -422,10 +425,10 @@ function kimiRow(detail: any, period: string): QuotaWindow | undefined {
  * some payloads report `remaining` instead of `used`. Duplicate windows
  * collapse to one (summary wins), rows sort shortest window first.
  *
- * Only the units in {@link KIMI_TIME_UNIT_MINUTES} are mapped: a
- * `TIME_UNIT_MONTH` row is dropped until the display handles monthly
- * windows. The optional `boosterWallet` (prepaid balance) is likewise not
- * mapped — a balance does not fit the quota-window display.
+ * Window types map to the 5h / daily / weekly / monthly rows; a unit outside
+ * {@link KIMI_TIME_UNIT_MINUTES} yields no row. The optional `boosterWallet`
+ * (prepaid balance) is likewise not mapped — a balance does not fit the
+ * quota-window display.
  */
 function parseKimiUsage(data: any): QuotaWindow[] {
   const byWindow = new Map<number, QuotaWindow>();

--- a/packages/pi-usage-block/src/builtin.ts
+++ b/packages/pi-usage-block/src/builtin.ts
@@ -15,6 +15,7 @@
  *   - quota (OpenAI Codex): ChatGPT Codex subscription usage endpoint
  *   - balance (OpenRouter / DeepSeek): prepaid account balance endpoint
  *   - quota (OpenCode Go, Z.AI / Z.AI Coding CN): coding-plan quota endpoint
+ *   - quota (Kimi For Coding): coding-plan usage endpoint
  */
 import type {
   UsageProvider,
@@ -329,6 +330,98 @@ async function zhipuCodingQuota(host: string, apiKey: string): Promise<QuotaWind
     }));
 }
 
+// ── Kimi For Coding ───────────────────────────────────────────────────────
+
+/** Proto-style timeUnit enum → minutes multiplier. */
+const KIMI_TIME_UNIT_MINUTES: Record<string, number> = {
+  TIME_UNIT_MINUTE: 1,
+  TIME_UNIT_HOUR: 60,
+  TIME_UNIT_DAY: 1440,
+  TIME_UNIT_WEEK: 10080,
+};
+
+/** Non-negative integer, arriving as a decimal string or a number. */
+function kimiInt(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const n = Number(value);
+    return Number.isSafeInteger(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+/** Rolling-window minutes from a limits[] item's proto-style `window`. */
+function kimiWindowMinutes(item: any): number | undefined {
+  const duration = kimiInt(item?.window?.duration);
+  const multiplier = KIMI_TIME_UNIT_MINUTES[item?.window?.timeUnit];
+  if (duration === undefined || duration === 0 || multiplier === undefined) return undefined;
+  return duration * multiplier;
+}
+
+/** Short period label: "5h", "daily", "weekly", … */
+function kimiPeriodLabel(minutes: number): string {
+  if (minutes === 300) return "5h";
+  if (minutes === 1440) return "daily";
+  if (minutes === 10080) return "weekly";
+  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+}
+
+/** One usage row (`detail`) → QuotaWindow. Skips non-integer/zero-limit rows. */
+function kimiRow(detail: any, period: string): QuotaWindow | undefined {
+  const used = kimiInt(detail?.used);
+  const limit = kimiInt(detail?.limit);
+  if (used === undefined || limit === undefined || limit === 0) return undefined;
+  const reset = typeof detail?.resetTime === "string" ? new Date(detail.resetTime) : undefined;
+  return {
+    period,
+    used,
+    limit,
+    unit: "requests", // plan usage counts — the endpoint exposes no finer unit
+    resetAt: reset !== undefined && !Number.isNaN(reset.getTime()) ? reset : undefined,
+  };
+}
+
+/**
+ * Parse the Kimi usage payload into windows keyed by rolling duration.
+ *
+ * `usage` is the plan's weekly summary (the backend omits its window);
+ * `limits[]` carries per-window rows (the 5-hour limit arrives as duration
+ * 300 TIME_UNIT_MINUTE). Numbers arrive as decimal strings or numbers.
+ * Duplicate windows collapse to one (summary wins), rows sort shortest
+ * window first. The optional `boosterWallet` (prepaid balance) is not
+ * mapped — a balance does not fit the quota-window display.
+ */
+function parseKimiUsage(data: any): QuotaWindow[] {
+  const byWindow = new Map<number, QuotaWindow>();
+  const summary = kimiRow(data?.usage, "weekly");
+  if (summary) byWindow.set(10080, summary);
+  for (const item of Array.isArray(data?.limits) ? data.limits : []) {
+    const minutes = kimiWindowMinutes(item);
+    if (minutes === undefined || byWindow.has(minutes)) continue;
+    const row = kimiRow(item?.detail, kimiPeriodLabel(minutes));
+    if (row) byWindow.set(minutes, row);
+  }
+  return [...byWindow.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, w]) => w);
+}
+
+/**
+ * Kimi For Coding: GET https://api.kimi.com/coding/v1/usages.
+ *
+ * The managed usage endpoint the official kimi-code CLI reads. The OAuth
+ * token (when pi resolves one instead of an API key) is re-resolved on every
+ * poll so short-lived tokens refresh after expiry.
+ */
+async function kimiCodingUsage(apiKey: string): Promise<QuotaWindow[]> {
+  const data = await fetchJson("https://api.kimi.com/coding/v1/usages", apiKey);
+  return parseKimiUsage(data);
+}
+
 // ── Registry of built-in definitions ──────────────────────────────────────
 
 export interface BuiltinContext {
@@ -418,6 +511,17 @@ export const BUILTIN_PROVIDERS: BuiltinDef[] = [
     build: ({ apiKey }) => ({
       kind: "quota", id: "zai-coding-cn", name: "Z.AI Coding CN", source: "api",
       fetchUsage: () => zhipuCodingQuota("https://open.bigmodel.cn", apiKey),
+    }),
+  },
+  {
+    id: "kimi-coding",
+    build: ({ resolveApiKey }) => ({
+      kind: "quota", id: "kimi-coding", name: "Kimi For Coding", source: "api",
+      fetchUsage: async () => {
+        const key = await resolveApiKey();
+        if (!key) throw new Error("Kimi Coding credential unavailable");
+        return kimiCodingUsage(key);
+      },
     }),
   },
 ];


### PR DESCRIPTION
## Summary

Adds a built-in usage provider for the **Kimi For Coding** plan (`kimi-coding` provider key), so the usage status bar shows the coding plan's rolling quota windows — e.g. `Kimi For Coding 🟢3% ↺2h5m 40% ↺3d`.

- Polls `GET https://api.kimi.com/coding/v1/usages` — the managed usage endpoint the official [kimi-code](https://github.com/MoonshotAI/kimi-code) CLI reads (verified live; contract cross-checked against kimi-code's `managed-usage.ts` and narumiruna's pi-usage implementation).
- Maps the payload to `QuotaWindow[]`:
  - top-level `usage` → the weekly summary row (the backend omits its window; it is the weekly limit),
  - `limits[]` → per-window rows (the 5-hour limit arrives as `duration: 300, TIME_UNIT_MINUTE`),
  - windows dedupe by duration (summary wins) and sort shortest-first.
- Maps 5h / daily / weekly / monthly windows; a `timeUnit` outside that table yields no row.
- Handles the endpoint's quirks: counts arrive as decimal strings **or** numbers, and as consumed `used` **or** `remaining` (falling back to `used = limit − remaining`, as kimi-code's own parser does); proto-style `timeUnit` enums, with bare `MINUTE` and `TIME_UNIT_MINUTE` both accepted; ISO reset timestamps under any of the `resetTime` / `resetAt` / `reset_time` / `reset_at` spellings (an unparsable value drops the reset, not the row); malformed/zero-limit rows skipped; empty payload → no windows.
- The credential is re-resolved via `resolveApiKey` on every poll (same pattern as the OpenAI Codex builtin), so short-lived OAuth tokens refresh after expiry; plain API keys work as-is.
- The optional `boosterWallet` (prepaid balance) is intentionally not mapped — a balance does not fit the quota-window display model.

## Testing

- `npx tsc --noEmit` clean; `node --test packages/pi-usage-block/src/*.test.ts` — 11 pass, 8 of them new for this provider: weekly + 5h mapping (URL + Bearer header asserted), numeric/duplicate/daily windows, monthly window, `remaining`-only rows with reset-spelling and `timeUnit`-casing tolerance, malformed rows, empty payload, per-poll credential re-resolution, missing credential.
- Smoke-tested live against `api.kimi.com` with an API key (HTTP 200; payload parses to the expected 5h window). The `remaining` fallback, the alternate reset spellings and the monthly window were verified against kimi-code's `managed-usage.ts` plus its tests, not against a live account.

## Notes

- Follows the existing Z.AI coding-plan builtin pattern (quota, `api` source); registers automatically when the user has a `kimi-coding` credential.
- Reference implementations studied: [narumiruna/pi-usage](https://github.com/narumiruna/pi-extensions) `kimi-coding` provider and MoonshotAI's kimi-code CLI.
